### PR TITLE
Allow builders to have access to /item?

### DIFF
--- a/src/info/tregmine/commands/ItemCommand.java
+++ b/src/info/tregmine/commands/ItemCommand.java
@@ -26,7 +26,7 @@ public class ItemCommand extends AbstractCommand
         if (args.length == 0) {
             return false;
         }
-        if (!player.isAdmin()) {
+        if (!player.isAdmin() || !player.isBuilder()) {
             return false;
         }
 


### PR DESCRIPTION
Response to request from Freezie_455
When considering this remember that /item is not /give, this command cant be used to give other players items
