### PR TITLE
Update BlessedBlockListener - EntityBreakDoor/onDoorBreak

### DIFF
--- a/src/info/tregmine/listeners/BlessedBlockListener.java
+++ b/src/info/tregmine/listeners/BlessedBlockListener.java
@@ -162,6 +162,21 @@ public class BlessedBlockListener implements Listener
     }
 
     @EventHandler
+    public void onDoorBreak(EntityBreakDoorEvent event)
+    {
+        Location l = event.getBlock().getLocation();
+        Entity e = event.getEntity();
+        
+        Map<Location, Integer> b = plugin.getBlessedBlocks();
+        
+        if( b.containsKey(l)) {
+            if( e instanceof Zombie ) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
     public void onBlockPlace(BlockPlaceEvent event)
     {
         Block block = event.getBlockPlaced();


### PR DESCRIPTION
Fix for zombies being able to break blessed doors gaining access to areas they shouldn't.
