### PR TITLE
Update TregminePlayerListener.java

### DIFF
--- a/src/info/tregmine/listeners/TregminePlayerListener.java
+++ b/src/info/tregmine/listeners/TregminePlayerListener.java
@@ -515,15 +515,6 @@ public class TregminePlayerListener implements Listener
     }
 
     @EventHandler
-    public void onPlayerMove(PlayerMoveEvent event)
-    {
-        TregminePlayer player = this.plugin.getPlayer(event.getPlayer());
-        if (player == null) {
-            event.getPlayer().kickPlayer("error loading profile!");
-        }
-    }
-
-    @EventHandler
     public void onPlayerPickupItem(PlayerPickupItemEvent event)
     {
         TregminePlayer player = this.plugin.getPlayer(event.getPlayer());


### PR DESCRIPTION
Removed a player move event, Reason: It is duplicated in the ZonePlayerListener which also logs issues - which is better. Two events of the same thing is silly.
