### PR TITLE
Update FishyBlockListener.java

### DIFF
--- a/src/info/tregmine/listeners/FishyBlockListener.java
+++ b/src/info/tregmine/listeners/FishyBlockListener.java
@@ -362,6 +362,10 @@ public class FishyBlockListener implements Listener
         Map<Location, FishyBlock> fishyBlocks = plugin.getFishyBlocks();
 
         TregminePlayer player = plugin.getPlayer(event.getPlayer());
+        
+        if(player.getChatState() != TregminePlayer.ChatState.CHAT){
+            return;
+        }
 
         Block block = event.getClickedBlock();
         BlockFace face = event.getBlockFace();


### PR DESCRIPTION
Should fix a bug where you could do /sell then go into a fishy block chat state thus losing items in the /sell window.
