### PR TITLE
A fix for the new Keyword/Alerts AND read desc

### DIFF
--- a/src/info/tregmine/database/db/DBPlayerDAO.java
+++ b/src/info/tregmine/database/db/DBPlayerDAO.java
@@ -149,13 +149,14 @@ public class DBPlayerDAO implements IPlayerDAO
     @Override
     public TregminePlayer createPlayer(Player wrap) throws DAOException
     {
-        String sql = "INSERT INTO player (player_name, player_rank) VALUE (?, ?)";
+        String sql = "INSERT INTO player (player_name, player_rank, player_keywords) VALUE (?, ?, ?)";
 
         TregminePlayer player = new TregminePlayer(wrap);
 
         try (PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setString(1, player.getName());
             stmt.setString(2, player.getRank().toString());
+            stmt.setString(3, player.getDisplayName());
             stmt.execute();
 
             stmt.executeQuery("SELECT LAST_INSERT_ID()");


### PR DESCRIPTION
New people wouldn't be able to be added to the db because of a bug. Did testing today; Everything works now.

Also in the ForceBlock Command dingy. This needs to be fixed:

toPlayer.sendMessage(ChatColor.AQUA + player.getChatName() + ChatColor.AQUA + " tried to force you into a channel!");
            player.sendMessage(ChatColor.AQUA + "Can not force " + toPlayer.getChatName() + ChatColor.AQUA + " into a channel!");

(Basically adding ChatColor.AQUA after displaying the name as the name colour continues.)
