### PR TITLE
Allow admins to see msg's when msg'ing an invisible person

### DIFF
--- a/src/info/tregmine/commands/MsgCommand.java
+++ b/src/info/tregmine/commands/MsgCommand.java
@@ -66,7 +66,7 @@ public class MsgCommand extends AbstractCommand
 
         // Show message in senders terminal, as long as the recipient isn't
         // invisible, to prevent /msg from giving away hidden players presence
-        if (!recvPlayer.hasFlag(TregminePlayer.Flags.INVISIBLE)) {
+        if (!recvPlayer.hasFlag(TregminePlayer.Flags.INVISIBLE) || player.getRank().canSeeHiddenInfo()) {
             player.sendMessage(GREEN + "(to) " + recvPlayer.getChatName()
                     + GREEN + ": " + message);
         }


### PR DESCRIPTION
If the player can see the person is online (even if they're vanished) why block them from seeing the chat?
Quick fix. forgot last week
