### PR TITLE
Support for disguised fishy blocks.

### DIFF
--- a/src/info/tregmine/listeners/FishyBlockListener.java
+++ b/src/info/tregmine/listeners/FishyBlockListener.java
@@ -735,12 +735,6 @@ public class FishyBlockListener implements Listener
         TregminePlayer player = plugin.getPlayer(event.getPlayer());
 
         Block block = event.getBlock();
-        if (block.getType() != Material.OBSIDIAN &&
-            block.getType() != Material.WALL_SIGN) {
-
-            return;
-        }
-
         Location loc = block.getLocation();
 
         Map<Location, FishyBlock> fishyBlocks = plugin.getFishyBlocks();


### PR DESCRIPTION
It checks for the location and stuff, so making sure they're breaking signs/obby is just pointless - This way it looks for the block rather than it being obsidian meaning disguised blocks can be broken. Just not produced legitimately... yet.
