### PR TITLE
Multi world inventory support.

### DIFF
--- a/src/info/tregmine/listeners/ZonePlayerListener.java
+++ b/src/info/tregmine/listeners/ZonePlayerListener.java
@@ -280,20 +280,28 @@ public class ZonePlayerListener implements Listener
     @EventHandler
     public void onPlayerMoveLot(PlayerLotChangeEvent event)
     {
+        if (event.getNew() == null) {
+            return;
+        }
+        
         if (!event.getNew().hasFlag(Lot.Flags.FLIGHT_ALLOWED) &&
             !event.getPlayer().getRank().canModifyZones()) {
+
             event.getPlayer().setFlying(false);
         }
 
-        if (event.getNew().isOwner(event.getPlayer())) { // Owner of the lot so bypasses private flag.
+        // Owner of the lot so bypasses private flag.
+        if (event.getNew().isOwner(event.getPlayer())) {
             return;
         }
 
-        if (event.getPlayer().getRank().canModifyZones()) { // Let admins bypass protection, but warn them just incase.
+        // Let admins bypass protection, but warn them just incase.
+        if (event.getPlayer().getRank().canModifyZones()) {
             return;
         }
 
-        if (!event.getNew().hasFlag(Lot.Flags.PRIVATE)) { // If not private flagged lot, then return.
+        // If not private flagged lot, then return.
+        if (!event.getNew().hasFlag(Lot.Flags.PRIVATE)) {
             return;
         }
 
@@ -364,9 +372,9 @@ public class ZonePlayerListener implements Listener
                         movePlayerBack(player, movingFrom, movingTo);
                         return;
                     }
-                    else if (currentZone.hasFlag(Zone.Flags.REQUIRE_RESIDENCY) && 
-                            (player.getRank() == Rank.TOURIST || 
-                             player.getRank() == Rank.SETTLER || 
+                    else if (currentZone.hasFlag(Zone.Flags.REQUIRE_RESIDENCY) &&
+                            (player.getRank() == Rank.TOURIST ||
+                             player.getRank() == Rank.SETTLER ||
                              player.getRank() == Rank.UNVERIFIED)) {
                         blockedMessage(currentZone, player);
                         movePlayerBack(player, movingFrom, movingTo);
@@ -399,13 +407,14 @@ public class ZonePlayerListener implements Listener
         }
     }
 
+
     @EventHandler
     public void onPlayerChangedWorld(PlayerChangedWorldEvent event)
     {
-        TregminePlayer player = plugin.getPlayer(event.getPlayer());        
+        TregminePlayer player = plugin.getPlayer(event.getPlayer());
         ZoneWorld world = plugin.getWorld(player.getWorld());
-        
         World cWorld = player.getWorld();
+
         if (    cWorld.equals(plugin.getServer().getWorld("world")) || 
                 cWorld.equals(plugin.getServer().getWorld("world_the_end")) || 
                 cWorld.equals(plugin.getServer().getWorld("world_nether"))) {
@@ -577,7 +586,7 @@ public class ZonePlayerListener implements Listener
         player.sendMessage(ChatColor.RED + "[" + currentZone.getName() + "] "
                 + "You are banned from " + currentZone.getName() + ".");
     }
-    
+
     private void blockedMessage(Zone currentZone, TregminePlayer player)
     {
         player.sendMessage(ChatColor.RED + "[" + currentZone.getName() + "] "


### PR DESCRIPTION
So the concept should work, but I'm not fully familiar with the way out worlds work.

In theory this should, on world change, check their world and if its either world (Overworld) world_the_end (End) or world_nether (Nether) then set the inventory to 'survival' which is what we use currently to store all inventories.

If its not one of the three above, then load the inventory world.getName() which will load a dynamic inventory based on what world they go into. It also saves the previous inventory.

So in all theory it should work. but triple check world names and such.
