### PR TITLE
Mining Fatigue on Block Break

### DIFF
--- a/src/info/tregmine/listeners/ZoneBlockListener.java
+++ b/src/info/tregmine/listeners/ZoneBlockListener.java
@@ -14,7 +14,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockFromToEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-
+import org.bukkit.potion.*;
 //import org.bukkit.entity.HumanEntity;
 //import org.bukkit.entity.Player;
 
@@ -63,6 +63,7 @@ public class ZoneBlockListener implements Listener
         }*/
 
         event.setCancelled(true);
+        player.addPotionEffect(new PotionEffect(PotionEffectType.SLOW_DIGGING, 5, 2));
     }
 
     @EventHandler


### PR DESCRIPTION
Appears to be a bit of an issue that if you have a fast pick or something, and then break a lot of blocks you can bypass some protection. So I decided to apply mining fatigue to the user on block break for 5 seconds, which should prevent a lot of issues like that.
