### PR TITLE
Potential (Untested) fix for Chat

### DIFF
--- a/src/info/tregmine/events/CallEventListener.java
+++ b/src/info/tregmine/events/CallEventListener.java
@@ -135,6 +135,7 @@ public class CallEventListener implements Listener
     {
         TregminePlayer player = plugin.getPlayer(event.getPlayer());
         if (player.getChatState() != TregminePlayer.ChatState.CHAT) {
+            event.setCancelled(true);
             return;
         }
 


### PR DESCRIPTION
Okay so its a known fact that theres a bug that was generated when I made this event.

My theoretical opinion on the bug is that this event is getting called after the other events have executed such as the command listeners. Whereas we want this to be triggered first as this is what posts to chat and not to the user.

So I'm trying to change the event priority in the hope that this will make it trigger first and prevent the bug.
Unfortunately, I had to have my computer defaulted so I dont have any of my Tregmine Testing Environment so I cant test this.
